### PR TITLE
(re-)subscribe to mqtt topics after reconnect

### DIFF
--- a/WallPanelApp/build.gradle
+++ b/WallPanelApp/build.gradle
@@ -124,7 +124,7 @@ dependencies {
     kapt "com.google.dagger:dagger-android-processor:$versions.dagger"
 
     // MQTT
-    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.0'
+    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.1'
     implementation 'org.eclipse.paho:org.eclipse.paho.android.service:1.1.1', {
         exclude module: 'support-v4'
     }


### PR DESCRIPTION
Mqtt client will subscribe (again) to topics after a lost connection to broker got restored.
This is needed because I could not publish to wallpanel anymore if my broker got restarted (ioBroker, MQTT Adapter).

Also updated mqttv3 to 1.2.1 (this change is optional)