### PR TITLE
Screen sleep (and smooth fade-in/out animation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ audio | URL | ```{"audio": "http://<url>"}``` | Play the audio specified by the 
 relaunch | true | ```{"relaunch": true}``` | Relaunches the dashboard from configured launchUrl
 reload | true | ```{"reload": true}``` | Reloads the current page immediately 
 url | URL | ```{"url": "http://<url>"}``` | Browse to a new URL immediately
-wake | true | ```{"wake": true}``` | Wakes the screen if it is asleep
+wake | true | ```{"wake": true, "wakeTime": 180}``` | Wakes the screen if it is asleep. Option wakeTime (in seconds) is optional, default is 30 sec. (Note: wakeTime cannot be shorter than Androids Display Timeout setting)
+wake | false | ```{"wake": false}``` | Release screen wake (Note: screen will not turn off before Androids Display Timeout finished)
 speak | data | ```{"speak": "Hello!"}``` | Uses the devices TTS to speak the message
 brightness | data | ```{"brightness": 1}``` | Changes the screens brightness, value 1-255. 
 camera | data | ```{"camera": true}``` | Turns on/off camera streaming, requires camera to be enabled. 

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/activities/BrowserActivity.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/activities/BrowserActivity.kt
@@ -57,7 +57,7 @@ abstract class BrowserActivity : DaggerAppCompatActivity() {
     var zoomLevel = 1.0f
 
     // handler for received data from service
-    private val mBroadcastReceiver = object : BroadcastReceiver() {
+    private val mBroadcastReceiver: BroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             if (BROADCAST_ACTION_LOAD_URL == intent.action) {
                 val url = intent.getStringExtra(BROADCAST_ACTION_LOAD_URL)

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/utils/MqttUtils.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/utils/MqttUtils.kt
@@ -48,6 +48,7 @@ class MqttUtils {
         const val COMMAND_CAMERA = "camera"
         const val COMMAND_RELAUNCH = "relaunch"
         const val COMMAND_WAKE = "wake"
+        const val COMMAND_WAKETIME = "wakeTime"
         const val COMMAND_BRIGHTNESS = "brightness"
         const val COMMAND_NOTIFICATION = "notification"
         const val COMMAND_RELOAD = "reload"

--- a/WallPanelApp/src/main/res/layout/activity_browser.xml
+++ b/WallPanelApp/src/main/res/layout/activity_browser.xml
@@ -27,14 +27,17 @@
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="#000000"
         android:windowSoftInputMode="adjustResize">
 
         <WebView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:id="@+id/activity_browser_webview_native"
+            android:alpha="0.0"
             android:scrollbars="none"
-            android:visibility="gone" />
+            android:visibility="gone"
+            tools:alpha="1.0" />
 
     </RelativeLayout>
 


### PR DESCRIPTION
This is the feature that was asked for here: https://github.com/thanksmister/wallpanel-android/issues/37
Am testing it since some time and it works!

Changes:
- Extended existing `"wake": true` function by optional `"wakeTime"` option to tell panel how long the wakeLock should be held (before it was 30 seconds fixed)
- Added `"wake": false` command. This will release a previously set wakeLock. If Androids "Display Timeout" has finished at this point, the screen will turn off (or screensaver, if set)

To make it work: 

1. User **has to choose a short Display Timeout in Android settings**, lets say 15 Seconds.
2. Start wallpanel, browser activity open, wait until screen turns off
3. Send {"wake":true, "wakeTime":1800} -> Screen turns on
4. Wait more than 15 sec after wake or last touch action:
4a. If nothing else done, screen will turn off after 30 minutes (1800sec)
4b. Send {"wake":false} -> wakeLock released, screen turns off
4c. If {"wake":false} was send before Display Timeout finished (15 sec in example), screen will stay on until display timeout finished.

_Note: it may be needed to disable Androids BatteryOptimization for WallPanel to prevent Android from killing app after some time. (seems not needed on LineageOS 15.1, but maybe for other systems)_

Also added a **fade in/out animation** on WebView page loading and screen wake. Screen fades to/from black if a new url was set. FadeIn starts when page **has finished** loading! That way we have a more professional looking panel because no half loaded pages are shown. Also wake commands smoothly dim display. 
I can split fade feature to a separate PR if you prefer. There are still some enhancements possible (make configureable, fadeOut on wake:false, also dim brightness,...)