### PR TITLE
On screen wake cmd: screensaver brightness value is set even when disabled

### DIFF
--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/activities/BrowserActivity.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/activities/BrowserActivity.kt
@@ -288,8 +288,9 @@ abstract class BrowserActivity : DaggerAppCompatActivity() {
             } catch (e: Exception) {
                 Timber.e(e.message)
             }
+            resetScreenBrightness(true)
         }
-        resetScreenBrightness(true)
+
     }
 
     open fun resetScreenBrightness(screenSaver: Boolean = false) {


### PR DESCRIPTION
A bit complicated to explain the case, but I'll try. The bug appears when you screen wake via mqtt, do brightness control via mqtt and have screensaver disabled. 
The screen wake triggers the presence/inactivity mechanism, then after timeout, the `showScreenSaver` method is called which will set the brightness to the lower screensaver value. This causes the screen to dim after each wake depending on the different timeouts.

The changed line was probably simply missplaced. 

Thanks for maintaining this great project!