### PR TITLE
Mask mqtt password in settings fragment

### DIFF
--- a/WallPanelApp/build.gradle
+++ b/WallPanelApp/build.gradle
@@ -91,6 +91,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.legacy:legacy-support-v13:1.0.0'
     implementation 'androidx.legacy:legacy-preference-v14:1.0.0'
+    implementation 'androidx.preference:preference-ktx:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation 'com.google.android.gms:play-services-vision:18.0.0'

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/BaseSettingsFragment.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/BaseSettingsFragment.kt
@@ -75,7 +75,12 @@ open class BaseSettingsFragment : PreferenceFragmentCompat(), SharedPreferences.
                         preference.entries[index]
                     else null)
         } else {
-            preference.summary = stringValue
+            if (preference.key.equals(getString(R.string.key_setting_mqtt_password))) {
+                // mask password in settings list
+                preference.summary = stringValue.replace(Regex("."), "*");
+            } else {
+                preference.summary = stringValue
+            }
         }
         true
     }

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/CameraSettingsFragment.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/CameraSettingsFragment.kt
@@ -101,10 +101,10 @@ class CameraSettingsFragment : BaseSettingsFragment() {
 
         super.onViewCreated(view, savedInstanceState)
 
-        fpsPreference = findPreference(getString(R.string.key_setting_camera_fps)) as EditTextPreference
-        cameraPreference = findPreference(getString(R.string.key_setting_camera_enabled)) as SwitchPreference
+        fpsPreference = findPreference<EditTextPreference>(getString(R.string.key_setting_camera_fps)) as EditTextPreference
+        cameraPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_camera_enabled)) as SwitchPreference
 
-        rotatePreference = findPreference(Configuration.PREF_CAMERA_ROTATE) as ListPreference
+        rotatePreference = findPreference<ListPreference>(Configuration.PREF_CAMERA_ROTATE) as ListPreference
         rotatePreference!!.setDefaultValue(configuration.cameraRotate)
         rotatePreference!!.value = configuration.cameraRotate.toString()
         if(configuration.cameraRotate == 0f) {
@@ -126,7 +126,7 @@ class CameraSettingsFragment : BaseSettingsFragment() {
             true
         }
 
-        cameraListPreference = findPreference(getString(R.string.key_setting_camera_cameraid)) as ListPreference
+        cameraListPreference = findPreference<ListPreference>(getString(R.string.key_setting_camera_cameraid)) as ListPreference
         cameraListPreference?.setOnPreferenceChangeListener { preference, newValue ->
             if (preference is ListPreference) {
                 val index = preference.findIndexOfValue(newValue.toString())

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/FaceSettingsFragment.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/FaceSettingsFragment.kt
@@ -78,8 +78,8 @@ class FaceSettingsFragment : BaseSettingsFragment() {
 
         super.onViewCreated(view, savedInstanceState)
 
-        motionDetectionPreference = findPreference(getString(R.string.key_setting_camera_faceenabled)) as SwitchPreference
-        motionDetectionPreference2 = findPreference(getString(R.string.key_setting_camera_facewake)) as SwitchPreference
+        motionDetectionPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_camera_faceenabled)) as SwitchPreference
+        motionDetectionPreference2 = findPreference<SwitchPreference>(getString(R.string.key_setting_camera_facewake)) as SwitchPreference
 
         bindPreferenceSummaryToValue(motionDetectionPreference!!)
         bindPreferenceSummaryToValue(motionDetectionPreference2!!)

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/HttpSettingsFragment.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/HttpSettingsFragment.kt
@@ -88,10 +88,10 @@ class HttpSettingsFragment : BaseSettingsFragment() {
 
         super.onViewCreated(view, savedInstanceState)
 
-        httpRestPreference = findPreference(getString(R.string.key_setting_http_restenabled)) as SwitchPreference
-        httpMjpegPreference = findPreference(getString(R.string.key_setting_http_mjpegenabled)) as SwitchPreference
-        httpMjpegStreamsPreference = findPreference(getString(R.string.key_setting_http_mjpegmaxstreams)) as EditTextPreference
-        httpPortPreference = findPreference(getString(R.string.key_setting_http_port)) as EditTextPreference
+        httpRestPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_http_restenabled)) as SwitchPreference
+        httpMjpegPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_http_mjpegenabled)) as SwitchPreference
+        httpMjpegStreamsPreference = findPreference<EditTextPreference>(getString(R.string.key_setting_http_mjpegmaxstreams)) as EditTextPreference
+        httpPortPreference = findPreference<EditTextPreference>(getString(R.string.key_setting_http_port)) as EditTextPreference
 
         bindPreferenceSummaryToValue(httpRestPreference!!)
         bindPreferenceSummaryToValue(httpMjpegPreference!!)
@@ -101,7 +101,7 @@ class HttpSettingsFragment : BaseSettingsFragment() {
         val wm = activity!!.applicationContext.getSystemService(WIFI_SERVICE) as WifiManager
         val ip = Formatter.formatIpAddress(wm.connectionInfo.ipAddress)
 
-        val description = findPreference(getString(R.string.key_setting_directions)) as Preference
+        val description = findPreference<Preference>(getString(R.string.key_setting_directions)) as Preference
         description.summary = getString(R.string.pref_mjpeg_streaming_description, ip )
     }
 }

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/MotionSettingsFragment.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/MotionSettingsFragment.kt
@@ -77,11 +77,11 @@ class MotionSettingsFragment : BaseSettingsFragment() {
 
         super.onViewCreated(view, savedInstanceState)
 
-        motionDetectionPreference = findPreference(getString(R.string.key_setting_camera_motionenabled)) as SwitchPreference
-        motionWakePreference = findPreference(getString(R.string.key_setting_camera_motionwake)) as SwitchPreference
-        motionLeniencyPreference = findPreference(getString(R.string.key_setting_camera_motionleniency)) as EditTextPreference
-        motionLumaPreference = findPreference(getString(R.string.key_setting_camera_motionminluma)) as EditTextPreference
-        motionClearPreference = findPreference(getString(R.string.key_setting_motion_clear)) as EditTextPreference
+        motionDetectionPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_camera_motionenabled)) as SwitchPreference
+        motionWakePreference = findPreference<SwitchPreference>(getString(R.string.key_setting_camera_motionwake)) as SwitchPreference
+        motionLeniencyPreference = findPreference<EditTextPreference>(getString(R.string.key_setting_camera_motionleniency)) as EditTextPreference
+        motionLumaPreference = findPreference<EditTextPreference>(getString(R.string.key_setting_camera_motionminluma)) as EditTextPreference
+        motionClearPreference = findPreference<EditTextPreference>(getString(R.string.key_setting_motion_clear)) as EditTextPreference
 
         bindPreferenceSummaryToValue(motionDetectionPreference!!)
         bindPreferenceSummaryToValue(motionWakePreference!!)

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/MqttSettingsFragment.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/MqttSettingsFragment.kt
@@ -18,6 +18,7 @@ package com.thanksmister.iot.wallpanel.ui.fragments
 
 import android.content.Context
 import android.os.Bundle
+import android.text.InputType
 import android.view.*
 import androidx.preference.SwitchPreference
 import androidx.preference.EditTextPreference
@@ -76,13 +77,18 @@ class MqttSettingsFragment : BaseSettingsFragment() {
 
         super.onViewCreated(view, savedInstanceState)
 
-        mqttPreference = findPreference(getString(R.string.key_setting_mqtt_enabled)) as SwitchPreference
-        mqttBrokerAddress = findPreference(getString(R.string.key_setting_mqtt_servername)) as EditTextPreference
-        mqttBrokerPort = findPreference(getString(R.string.key_setting_mqtt_serverport)) as EditTextPreference
-        mqttClientId = findPreference(getString(R.string.key_setting_mqtt_clientid)) as EditTextPreference
-        mqttBaseTopic = findPreference(getString(R.string.key_setting_mqtt_basetopic)) as EditTextPreference
-        mqttUsername = findPreference(getString(R.string.key_setting_mqtt_username)) as EditTextPreference
-        mqttPassword = findPreference(getString(R.string.key_setting_mqtt_password)) as EditTextPreference
+        mqttPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_mqtt_enabled)) as SwitchPreference
+        mqttBrokerAddress = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_servername)) as EditTextPreference
+        mqttBrokerPort = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_serverport)) as EditTextPreference
+        mqttClientId = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_clientid)) as EditTextPreference
+        mqttBaseTopic = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_basetopic)) as EditTextPreference
+        mqttUsername = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_username)) as EditTextPreference
+        mqttPassword = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_password)) as EditTextPreference
+
+        mqttPassword?.setOnBindEditTextListener {editText ->
+            // mask password in edit dialog
+            editText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+        }
 
         bindPreferenceSummaryToValue(mqttPreference!!)
         bindPreferenceSummaryToValue(mqttBrokerAddress!!)

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/QrCodeSettingsFragment.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/QrCodeSettingsFragment.kt
@@ -72,7 +72,7 @@ class QrCodeSettingsFragment : BaseSettingsFragment() {
 
         super.onViewCreated(view, savedInstanceState)
 
-        qrCodePreference = findPreference(getString(R.string.key_setting_camera_qrcodeenabled)) as SwitchPreference
+        qrCodePreference = findPreference<SwitchPreference>(getString(R.string.key_setting_camera_qrcodeenabled)) as SwitchPreference
 
         bindPreferenceSummaryToValue(qrCodePreference!!)
     }

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/SensorsSettingsFragment.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/SensorsSettingsFragment.kt
@@ -77,18 +77,18 @@ class SensorsSettingsFragment : BaseSettingsFragment() {
 
         super.onViewCreated(view, savedInstanceState)
 
-        sensorsPreference = findPreference(getString(R.string.key_setting_sensors_enabled)) as SwitchPreference
-        mqttPublishFrequency = findPreference(getString(R.string.key_setting_mqtt_sensorfrequency)) as EditTextPreference
+        sensorsPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_sensors_enabled)) as SwitchPreference
+        mqttPublishFrequency = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_sensorfrequency)) as EditTextPreference
 
         bindPreferenceSummaryToValue(sensorsPreference!!)
         bindPreferenceSummaryToValue(mqttPublishFrequency!!)
 
         val mSensorManager = activity!!.getSystemService(Context.SENSOR_SERVICE) as SensorManager
-        setSensorPreferenceSummary(findPreference(getString(R.string.key_settings_sensors_temperature)), mSensorManager.getSensorList(Sensor.TYPE_AMBIENT_TEMPERATURE));
-        setSensorPreferenceSummary(findPreference(getString(R.string.key_settings_sensors_light)), mSensorManager.getSensorList(Sensor.TYPE_LIGHT));
-        setSensorPreferenceSummary(findPreference(getString(R.string.key_settings_sensors_magneticField)), mSensorManager.getSensorList(Sensor.TYPE_MAGNETIC_FIELD));
-        setSensorPreferenceSummary(findPreference(getString(R.string.key_settings_sensors_pressure)), mSensorManager.getSensorList(Sensor.TYPE_PRESSURE));
-        setSensorPreferenceSummary(findPreference(getString(R.string.key_settings_sensors_humidity)), mSensorManager.getSensorList(Sensor.TYPE_RELATIVE_HUMIDITY));
+        setSensorPreferenceSummary(findPreference<Preference>(getString(R.string.key_settings_sensors_temperature)) as Preference, mSensorManager.getSensorList(Sensor.TYPE_AMBIENT_TEMPERATURE));
+        setSensorPreferenceSummary(findPreference<Preference>(getString(R.string.key_settings_sensors_light)) as Preference, mSensorManager.getSensorList(Sensor.TYPE_LIGHT));
+        setSensorPreferenceSummary(findPreference<Preference>(getString(R.string.key_settings_sensors_magneticField)) as Preference, mSensorManager.getSensorList(Sensor.TYPE_MAGNETIC_FIELD));
+        setSensorPreferenceSummary(findPreference<Preference>(getString(R.string.key_settings_sensors_pressure)) as Preference, mSensorManager.getSensorList(Sensor.TYPE_PRESSURE));
+        setSensorPreferenceSummary(findPreference<Preference>(getString(R.string.key_settings_sensors_humidity)) as Preference, mSensorManager.getSensorList(Sensor.TYPE_RELATIVE_HUMIDITY));
     }
 
     private fun setSensorPreferenceSummary(preference: Preference, sensorList: List<Sensor>) {

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/SettingsFragment.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/SettingsFragment.kt
@@ -147,18 +147,18 @@ class SettingsFragment : BaseSettingsFragment() {
 
         super.onViewCreated(view, savedInstanceState)
 
-        dashboardPreference = findPreference(getString(R.string.key_setting_app_launchurl)) as EditTextPreference
-        browserHeaderPreference = findPreference(getString(R.string.key_setting_browser_user_agent)) as EditTextPreference
-        preventSleepPreference = findPreference(getString(R.string.key_setting_app_preventsleep)) as SwitchPreference
-        browserActivityPreference = findPreference(getString(R.string.key_setting_app_showactivity)) as SwitchPreference
-        openOnBootPreference = findPreference(getString(R.string.key_setting_android_startonboot)) as SwitchPreference
-        hadwareAcceleration = findPreference(getString(R.string.key_hadware_accelerated_enabled)) as SwitchPreference
-        browserRefreshPreference = findPreference(getString(R.string.key_pref_browser_refresh)) as SwitchPreference
-        clockSaverPreference = findPreference(getString(R.string.key_screensaver)) as SwitchPreference
-        walllpaperSaverPreference = findPreference(getString(R.string.key_screensaver_wallpaper)) as SwitchPreference
-        inactivityPreference = findPreference(PREF_SCREEN_INACTIVITY_TIME) as ListPreference
-        dimPreference = findPreference(PREF_SCREENSAVER_DIM_VALUE) as ListPreference
-        screenBrightness = findPreference(PREF_SCREEN_BRIGHTNESS) as SwitchPreference
+        dashboardPreference = findPreference<EditTextPreference>(getString(R.string.key_setting_app_launchurl)) as EditTextPreference
+        browserHeaderPreference = findPreference<EditTextPreference>(getString(R.string.key_setting_browser_user_agent)) as EditTextPreference
+        preventSleepPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_app_preventsleep)) as SwitchPreference
+        browserActivityPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_app_showactivity)) as SwitchPreference
+        openOnBootPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_android_startonboot)) as SwitchPreference
+        hadwareAcceleration = findPreference<SwitchPreference>(getString(R.string.key_hadware_accelerated_enabled)) as SwitchPreference
+        browserRefreshPreference = findPreference<SwitchPreference>(getString(R.string.key_pref_browser_refresh)) as SwitchPreference
+        clockSaverPreference = findPreference<SwitchPreference>(getString(R.string.key_screensaver)) as SwitchPreference
+        walllpaperSaverPreference = findPreference<SwitchPreference>(getString(R.string.key_screensaver_wallpaper)) as SwitchPreference
+        inactivityPreference = findPreference<ListPreference>(PREF_SCREEN_INACTIVITY_TIME) as ListPreference
+        dimPreference = findPreference<ListPreference>(PREF_SCREENSAVER_DIM_VALUE) as ListPreference
+        screenBrightness = findPreference<SwitchPreference>(PREF_SCREEN_BRIGHTNESS) as SwitchPreference
 
         bindPreferenceSummaryToValue(dashboardPreference!!)
         bindPreferenceSummaryToValue(preventSleepPreference!!)


### PR DESCRIPTION
This is feature requested in https://github.com/thanksmister/wallpanel-android/issues/117
Passwords are not visible in clear-text anymore in mqtt settings but as `******`

(Poor google, I couldn't believe that this has to be handled manually. There is not password setting in EditTextPreference.)

`androidx.preference:preference-ktx` is needed for `setOnBindEditTextListener`. Sadly it requires all the preferences-type definitions, else "Type inference failed..Please specify it explicitly"