### PR TITLE
Don't set TTS language from default language

### DIFF
--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/TextToSpeechModule.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/TextToSpeechModule.kt
@@ -54,7 +54,6 @@ class TextToSpeechModule( base: Context?) : ContextWrapper(base),
 
     override fun onInit(status: Int) {
         if (status == TextToSpeech.SUCCESS && textToSpeech != null) {
-            textToSpeech?.language = Locale.getDefault()
             textToSpeech?.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
                 override fun onError(p0: String?) {
                     Timber.e(p0)


### PR DESCRIPTION
This allows to use Android's TTS language instead of forcing
the user to use the systems default language.

Fixes: #148