### PR TITLE
Add a chance to dim at maximum allowed by device

### DIFF
--- a/WallPanelApp/src/main/res/values/donottranslate.xml
+++ b/WallPanelApp/src/main/res/values/donottranslate.xml
@@ -214,6 +214,7 @@
         <item>50%</item>
         <item>75%</item>
         <item>90%</item>
+        <item>99%</item>
     </string-array>
 
     <string-array name="dim_values">
@@ -226,6 +227,7 @@
         <item>50</item>
         <item>75</item>
         <item>90</item>
+        <item>99</item>
     </string-array>
 
 </resources>


### PR DESCRIPTION
There are tablets which limit by hardware the minimal screen brightness (0 doesn't mean completely off). This is a chance to reach this level as most as possible. 100% doesn't work, but with 99% device can be dimmed to the lowest possible value allowed by the unit. This is desirable in cases when the manufacturer already thougt about prohibiting a completely black screen by hardware design.