### PR TITLE
Added a blank screensaver option

### DIFF
--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/persistence/Configuration.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/persistence/Configuration.kt
@@ -239,6 +239,9 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
         get() = sharedPreferences.getInt(PREF_IMAGE_ROTATION, ROTATE_TIME_IN_MINUTES)
         set(value) = this.sharedPreferences.edit().putInt(PREF_IMAGE_ROTATION, value).apply()
 
+    val hasBlankScreenSaver: Boolean
+        get() = getBoolPref(R.string.key_screensaver_blank, R.string.default_screensaver_blank)
+
     val hasClockScreenSaver: Boolean
         get() = getBoolPref(R.string.key_screensaver, R.string.default_screensaver)
 

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/activities/BrowserActivity.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/activities/BrowserActivity.kt
@@ -269,7 +269,7 @@ abstract class BrowserActivity : DaggerAppCompatActivity() {
      * with the alarm disabled because the disable time will be longer than this.
      */
     open fun showScreenSaver() {
-        if ((configuration.hasClockScreenSaver || configuration.hasScreenSaverWallpaper) && !isFinishing) {
+        if ((configuration.hasBlankScreenSaver || configuration.hasClockScreenSaver || configuration.hasScreenSaverWallpaper) && !isFinishing) {
             inactivityHandler.removeCallbacks(inactivityCallback)
             try {
                 dialogUtils.showScreenSaver(this@BrowserActivity,

--- a/WallPanelApp/src/main/res/values/donottranslate.xml
+++ b/WallPanelApp/src/main/res/values/donottranslate.xml
@@ -133,6 +133,9 @@
     <string name="key_screensaver_wallpaper">settings_screensaver_wallpaper</string>
     <string name="default_screensaver_wallpaper">false</string>
 
+    <string name="key_screensaver_blank">settings_screensaver_blank</string>
+    <string name="default_screensaver_blank">false</string>
+
     <string name="key_setting_screen_brightness">setting_screen_brightness</string>
     <string name="default_setting_screen_brightness">150</string>
 

--- a/WallPanelApp/src/main/res/values/strings.xml
+++ b/WallPanelApp/src/main/res/values/strings.xml
@@ -212,6 +212,8 @@
     <string name="preference_title_screen_saver">Clock Screen Saver</string>
     <string name="preference_summary_screen_saver_settings_wallpaper">When active, uses unsplash.it to get random wallpapers</string>
     <string name="preference_title_screen_saver_wallpaper">Wallpaper Screen Saver</string>
+    <string name="preference_summary_screen_saver_settings_blank">When active, the screensaver displays a blank screen</string>
+    <string name="preference_title_screen_saver_blank">Blank Screen Saver</string>
 
     <string name="preference_title_inactivity">Start screensaver after…</string>
     <string name="preference_title_screensaver_dim">Dim screen…</string>

--- a/WallPanelApp/src/main/res/xml/pref_general.xml
+++ b/WallPanelApp/src/main/res/xml/pref_general.xml
@@ -91,6 +91,12 @@
             android:summary="@string/pref_button_brightness_summary"/>
 
         <SwitchPreference
+            android:defaultValue="@string/default_screensaver_blank"
+            android:title="@string/preference_title_screen_saver_blank"
+            android:summary="@string/preference_summary_screen_saver_settings_blank"
+            android:key="@string/key_screensaver_blank"/>
+
+        <SwitchPreference
             android:defaultValue="@string/default_screensaver"
             android:title="@string/preference_title_screen_saver"
             android:summary="@string/preference_summary_screen_saver_settings"


### PR DESCRIPTION
I was looking for a way to have a blank screen (rather than the clock or photos) that would come alive when touched. If I did the motion detection option, I could get the blank screen, but my tablet wasn't able to detect the motion at night.

To solve this, I've added an option to have a blank screen saver. Setting the screen dimming in combination with this option gives me the effect I was looking for.