### PR TITLE
Add Home Assistant MQTT discovery

### DIFF
--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/MQTTModule.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/MQTTModule.kt
@@ -77,17 +77,11 @@ class MQTTModule (base: Context?, var mqttOptions: MQTTOptions, private val list
         stop()
     }
 
-    fun publish(command: String, message : String) {
-        Timber.d("command: " + command)
-        Timber.d("message: " + message)
-         mqttService?.publish(command, message)
-    }
-
-    fun publishEx(topic: String, message : String, retain: Boolean) {
-        Timber.d("command: " + topic)
+    fun publish(topic: String, message : String, retain: Boolean) {
+        Timber.d("topic: " + topic)
         Timber.d("message: " + message)
         Timber.d("retain: $retain")
-        mqttService?.publishEx(topic, message, retain)
+        mqttService?.publish(topic, message, retain)
     }
 
     override fun subscriptionMessage(id: String, topic: String, payload: String) {

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/MQTTModule.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/MQTTModule.kt
@@ -83,6 +83,13 @@ class MQTTModule (base: Context?, var mqttOptions: MQTTOptions, private val list
          mqttService?.publish(command, message)
     }
 
+    fun publishEx(topic: String, message : String, retain: Boolean) {
+        Timber.d("command: " + topic)
+        Timber.d("message: " + message)
+        Timber.d("retain: $retain")
+        mqttService?.publishEx(topic, message, retain)
+    }
+
     override fun subscriptionMessage(id: String, topic: String, payload: String) {
         Timber.d("topic: " + topic)
         listener.onMQTTMessage(id, topic, payload)

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/SensorReader.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/SensorReader.kt
@@ -26,13 +26,14 @@ import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.os.BatteryManager
 import android.os.Handler
+import com.thanksmister.iot.wallpanel.R
 import org.json.JSONException
 import org.json.JSONObject
 import timber.log.Timber
 import java.util.*
 import javax.inject.Inject
 
-data class SensorInfo(val sensorType: String?, val unit: String?, val deviceClass: String?)
+data class SensorInfo(val sensorType: String?, val unit: String?, val deviceClass: String?, val displayName: String?)
 
 class SensorReader @Inject
 constructor(private val context: Context){
@@ -66,7 +67,7 @@ constructor(private val context: Context){
     }
 
     fun getSensors(): List<SensorInfo> {
-        return mSensorList.map { s -> SensorInfo(getSensorName(s.type), getSensorUnit(s.type), getSensorDeviceClass(s.type)) }
+        return mSensorList.map { s -> SensorInfo(getSensorName(s.type), getSensorUnit(s.type), getSensorDeviceClass(s.type), getSensorDisplayName(s.type)) }
     }
 
     fun startReadings(freqSeconds: Int, callback: SensorCallback) {
@@ -106,6 +107,17 @@ constructor(private val context: Context){
             Sensor.TYPE_MAGNETIC_FIELD -> return MAGNETIC_FIELD
             Sensor.TYPE_PRESSURE -> return PRESSURE
             Sensor.TYPE_RELATIVE_HUMIDITY -> return HUMIDITY
+        }
+        return null
+    }
+
+    private fun getSensorDisplayName(sensorType: Int): String? {
+        when (sensorType) {
+            Sensor.TYPE_AMBIENT_TEMPERATURE -> return context.getString(R.string.mqtt_sensor_temperature)
+            Sensor.TYPE_LIGHT -> return context.getString(R.string.mqtt_sensor_light)
+            Sensor.TYPE_MAGNETIC_FIELD -> return context.getString(R.string.mqtt_sensor_magnetic_field)
+            Sensor.TYPE_PRESSURE -> return context.getString(R.string.mqtt_sensor_pressure)
+            Sensor.TYPE_RELATIVE_HUMIDITY -> return context.getString(R.string.mqtt_sensor_humidity)
         }
         return null
     }

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/SensorReader.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/SensorReader.kt
@@ -79,6 +79,12 @@ constructor(private val context: Context){
         }
     }
 
+    fun refreshSensors() {
+        batteryHandler.post(batteryHandlerRunnable)
+        stopSensorReading()
+        startSensorReadings()
+    }
+
     fun stopReadings() {
         Timber.d("stopReadings")
         batteryHandler.removeCallbacksAndMessages(batteryHandlerRunnable)

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/SensorReader.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/SensorReader.kt
@@ -32,6 +32,8 @@ import timber.log.Timber
 import java.util.*
 import javax.inject.Inject
 
+data class SensorInfo(val sensorType: String?, val unit: String?, val deviceClass: String?)
+
 class SensorReader @Inject
 constructor(private val context: Context){
 
@@ -61,6 +63,10 @@ constructor(private val context: Context){
             if (getSensorName(s.type) != null)
                 mSensorList.add(s)
         }
+    }
+
+    fun getSensors(): List<SensorInfo> {
+        return mSensorList.map { s -> SensorInfo(getSensorName(s.type), getSensorUnit(s.type), getSensorDeviceClass(s.type)) }
     }
 
     fun startReadings(freqSeconds: Int, callback: SensorCallback) {
@@ -105,6 +111,19 @@ constructor(private val context: Context){
             Sensor.TYPE_MAGNETIC_FIELD -> return UNIT_UT
             Sensor.TYPE_PRESSURE -> return UNIT_HPA
             Sensor.TYPE_RELATIVE_HUMIDITY -> return UNIT_PERCENTAGE
+        }
+        return null
+    }
+
+    /**
+     * Map to Home Assistant device class for sensors
+     */
+    private fun getSensorDeviceClass(sensorType: Int): String? {
+        when(sensorType) {
+            Sensor.TYPE_AMBIENT_TEMPERATURE -> return "temperature"
+            Sensor.TYPE_LIGHT -> return "illuminance"
+            Sensor.TYPE_PRESSURE -> return "pressure"
+            Sensor.TYPE_RELATIVE_HUMIDITY -> return "humidity"
         }
         return null
     }
@@ -180,6 +199,7 @@ constructor(private val context: Context){
 
         publishSensorData(BATTERY, data)
     }
+
 
     companion object {
         const val BATTERY: String = "battery"

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/network/MQTTOptions.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/network/MQTTOptions.kt
@@ -90,6 +90,10 @@ constructor(private val configuration: Configuration) {
         return configuration.mqttTlsEnabled
     }
 
+    fun getHomeAssistantDiscovery(): Boolean {
+        return configuration.mqttHomeAssistantDiscovery
+    }
+
     companion object {
         const val SSL_BROKER_URL_FORMAT = "ssl://%s:%d"
         const val TCP_BROKER_URL_FORMAT = "tcp://%s:%d"

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/network/MQTTOptions.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/network/MQTTOptions.kt
@@ -90,10 +90,6 @@ constructor(private val configuration: Configuration) {
         return configuration.mqttTlsEnabled
     }
 
-    fun getHomeAssistantDiscovery(): Boolean {
-        return configuration.mqttHomeAssistantDiscovery
-    }
-
     companion object {
         const val SSL_BROKER_URL_FORMAT = "ssl://%s:%d"
         const val TCP_BROKER_URL_FORMAT = "tcp://%s:%d"

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/network/MQTTService.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/network/MQTTService.kt
@@ -72,13 +72,14 @@ class MQTTService(private var context: Context, options: MQTTOptions,
     override fun close() {
         Timber.d("close")
 
-        if(mqttOptions != null) {
-            val offlineMessage = MqttMessage(OFFLINE.toByteArray())
-            offlineMessage.isRetained = true
-            sendMessage("${mqttOptions!!.getBaseTopic()}${CONNECTION}", offlineMessage)
-        }
-
         mqttClient?.let {
+
+            mqttOptions?.let {
+                val offlineMessage = MqttMessage(OFFLINE.toByteArray())
+                offlineMessage.isRetained = true
+                sendMessage("${it.getBaseTopic()}${CONNECTION}", offlineMessage)
+            }
+
             it.setCallback(null)
             if (it.isConnected) {
                 it.disconnect(0)
@@ -90,7 +91,7 @@ class MQTTService(private var context: Context, options: MQTTOptions,
         mReady.set(false)
     }
 
-    override fun publishEx(topic: String, payload: String, retain: Boolean) {
+    override fun publish(topic: String, payload: String, retain: Boolean) {
         try {
             if (isReady) {
                 mqttClient?.let {
@@ -124,10 +125,6 @@ class MQTTService(private var context: Context, options: MQTTOptions,
         } catch (e: MqttException) {
             listener?.handleMqttException("Exception while publishing command $topic and it's payload to the MQTT broker.")
         }
-    }
-
-    override fun publish(command: String, payload: String) {
-        publishEx(mqttOptions?.getBaseTopic() + command, payload, SHOULD_RETAIN)
     }
 
     /**

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/network/MQTTServiceInterface.java
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/network/MQTTServiceInterface.java
@@ -24,9 +24,7 @@ public interface MQTTServiceInterface {
 
     boolean isReady();
 
-    void publish(String command, String payload);
-
-    void publishEx(String topic, String payload, boolean retain);
+    void publish(String topic, String payload, boolean retain);
 
     void reconfigure(Context context, MQTTOptions options, MQTTService.MqttManagerListener listener);
     

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/network/MQTTServiceInterface.java
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/network/MQTTServiceInterface.java
@@ -26,6 +26,8 @@ public interface MQTTServiceInterface {
 
     void publish(String command, String payload);
 
+    void publishEx(String topic, String payload, boolean retain);
+
     void reconfigure(Context context, MQTTOptions options, MQTTService.MqttManagerListener listener);
     
     void close() throws MqttException;

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/persistence/Configuration.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/persistence/Configuration.kt
@@ -169,7 +169,7 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
 
     val mqttBaseTopic: String
         get() = getStringPref(R.string.key_setting_mqtt_basetopic,
-                R.string.default_setting_mqtt_basetopic)
+                R.string.default_setting_mqtt_basetopic).trimEnd('/') + "/"
 
     val mqttClientId: String
         get() = getStringPref(R.string.key_setting_mqtt_clientid,
@@ -186,6 +186,12 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
     val mqttSensorFrequency: Int
         get() = getStringPref(R.string.key_setting_mqtt_sensorfrequency,
                 R.string.default_setting_mqtt_sensorfrequency).trim().toInt()
+
+    val mqttHomeAssistantDiscovery: Boolean
+        get() = getBoolPref(R.string.key_setting_mqtt_home_assistant_discovery,  R.string.default_setting_mqtt_home_assistant_discovery)
+
+    val mqttHomeAssistantName: String
+        get() = getStringPref(R.string.key_setting_mqtt_home_assistant_name, R.string.default_setting_mqtt_home_assistant_name)
 
     val androidStartOnBoot: Boolean
         get() = getBoolPref(R.string.key_setting_android_startonboot,

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/persistence/Configuration.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/persistence/Configuration.kt
@@ -169,7 +169,7 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
 
     val mqttBaseTopic: String
         get() = getStringPref(R.string.key_setting_mqtt_basetopic,
-                R.string.default_setting_mqtt_basetopic).trimEnd('/') + "/"
+                R.string.default_setting_mqtt_basetopic)
 
     val mqttClientId: String
         get() = getStringPref(R.string.key_setting_mqtt_clientid,
@@ -187,10 +187,13 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
         get() = getStringPref(R.string.key_setting_mqtt_sensorfrequency,
                 R.string.default_setting_mqtt_sensorfrequency).trim().toInt()
 
-    val mqttHomeAssistantDiscovery: Boolean
+    val mqttDiscovery: Boolean
         get() = getBoolPref(R.string.key_setting_mqtt_home_assistant_discovery,  R.string.default_setting_mqtt_home_assistant_discovery)
 
-    val mqttHomeAssistantName: String
+    val mqttDiscoveryTopic: String
+        get() = getStringPref(R.string.key_setting_mqtt_home_assistant_topic, R.string.default_setting_mqtt_home_assistant_topic)
+
+    val mqttDiscoveryDeviceName: String
         get() = getStringPref(R.string.key_setting_mqtt_home_assistant_name, R.string.default_setting_mqtt_home_assistant_name)
 
     val androidStartOnBoot: Boolean

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/MqttSettingsFragment.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/MqttSettingsFragment.kt
@@ -36,6 +36,8 @@ class MqttSettingsFragment : BaseSettingsFragment() {
     private var mqttBaseTopic: EditTextPreference? = null
     private var mqttUsername: EditTextPreference? = null
     private var mqttPassword: EditTextPreference? = null
+    private var mqttHomeAssistantDiscovery: SwitchPreference? = null
+    private var mqttHomeAssitantName: EditTextPreference? = null
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
@@ -84,6 +86,8 @@ class MqttSettingsFragment : BaseSettingsFragment() {
         mqttBaseTopic = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_basetopic)) as EditTextPreference
         mqttUsername = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_username)) as EditTextPreference
         mqttPassword = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_password)) as EditTextPreference
+        mqttHomeAssistantDiscovery = findPreference<SwitchPreference>(getString(R.string.key_setting_mqtt_home_assistant_discovery)) as SwitchPreference
+        mqttHomeAssitantName = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_home_assistant_name)) as EditTextPreference
 
         mqttPassword?.setOnBindEditTextListener {editText ->
             // mask password in edit dialog
@@ -97,5 +101,7 @@ class MqttSettingsFragment : BaseSettingsFragment() {
         bindPreferenceSummaryToValue(mqttBaseTopic!!)
         bindPreferenceSummaryToValue(mqttUsername!!)
         bindPreferenceSummaryToValue(mqttPassword!!)
+        bindPreferenceSummaryToValue(mqttHomeAssistantDiscovery!!)
+        bindPreferenceSummaryToValue(mqttHomeAssitantName!!)
     }
 }

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/MqttSettingsFragment.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/MqttSettingsFragment.kt
@@ -36,8 +36,9 @@ class MqttSettingsFragment : BaseSettingsFragment() {
     private var mqttBaseTopic: EditTextPreference? = null
     private var mqttUsername: EditTextPreference? = null
     private var mqttPassword: EditTextPreference? = null
-    private var mqttHomeAssistantDiscovery: SwitchPreference? = null
-    private var mqttHomeAssitantName: EditTextPreference? = null
+    private var mqttDiscovery: SwitchPreference? = null
+    private var mqttDiscoveryTopic: EditTextPreference? = null
+    private var mqttDiscoveryDeviceName: EditTextPreference? = null
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
@@ -86,8 +87,9 @@ class MqttSettingsFragment : BaseSettingsFragment() {
         mqttBaseTopic = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_basetopic)) as EditTextPreference
         mqttUsername = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_username)) as EditTextPreference
         mqttPassword = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_password)) as EditTextPreference
-        mqttHomeAssistantDiscovery = findPreference<SwitchPreference>(getString(R.string.key_setting_mqtt_home_assistant_discovery)) as SwitchPreference
-        mqttHomeAssitantName = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_home_assistant_name)) as EditTextPreference
+        mqttDiscovery = findPreference<SwitchPreference>(getString(R.string.key_setting_mqtt_home_assistant_discovery)) as SwitchPreference
+        mqttDiscoveryTopic = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_home_assistant_topic)) as EditTextPreference
+        mqttDiscoveryDeviceName = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_home_assistant_name)) as EditTextPreference
 
         mqttPassword?.setOnBindEditTextListener {editText ->
             // mask password in edit dialog
@@ -101,7 +103,8 @@ class MqttSettingsFragment : BaseSettingsFragment() {
         bindPreferenceSummaryToValue(mqttBaseTopic!!)
         bindPreferenceSummaryToValue(mqttUsername!!)
         bindPreferenceSummaryToValue(mqttPassword!!)
-        bindPreferenceSummaryToValue(mqttHomeAssistantDiscovery!!)
-        bindPreferenceSummaryToValue(mqttHomeAssitantName!!)
+        bindPreferenceSummaryToValue(mqttDiscovery!!)
+        bindPreferenceSummaryToValue(mqttDiscoveryTopic!!)
+        bindPreferenceSummaryToValue(mqttDiscoveryDeviceName!!)
     }
 }

--- a/WallPanelApp/src/main/res/values/donottranslate.xml
+++ b/WallPanelApp/src/main/res/values/donottranslate.xml
@@ -44,11 +44,12 @@
     <string name="default_setting_mqtt_servername">192.168.1.1</string>
     <string name="key_setting_mqtt_enabled">setting_mqtt_enabled</string>
     <string name="key_setting_mqtt_home_assistant_discovery">setting_mqtt_home_assistant_discovery</string>
+    <string name="key_setting_mqtt_home_assistant_topic">setting_mqtt_home_assistant_topic</string>
     <string name="key_setting_mqtt_home_assistant_name">setting_mqtt_home_assistant_name</string>
     <string name="key_setting_mqtt_tls_enabled">setting_mqtt_tls_enabled</string>
     <string name="default_setting_mqtt_enabled">false</string>
     <string name="default_setting_mqtt_home_assistant_discovery">false</string>
-    <string name="default_setting_mqtt_home_assistant_name">My Wall Panel</string>
+    <string name="default_setting_mqtt_home_assistant_topic">homeassistant</string>
     <string name="default_setting_mqtt_tts_enabled">false</string>
     <string name="default_setting_mqtt_basetopic">wallpanel/mywallpanel/</string>
     <string name="key_setting_mqtt_clientid">setting_mqtt_clientid</string>

--- a/WallPanelApp/src/main/res/values/donottranslate.xml
+++ b/WallPanelApp/src/main/res/values/donottranslate.xml
@@ -43,8 +43,12 @@
     <string name="key_setting_mqtt_servername">setting_mqtt_servername</string>
     <string name="default_setting_mqtt_servername">192.168.1.1</string>
     <string name="key_setting_mqtt_enabled">setting_mqtt_enabled</string>
+    <string name="key_setting_mqtt_home_assistant_discovery">setting_mqtt_home_assistant_discovery</string>
+    <string name="key_setting_mqtt_home_assistant_name">setting_mqtt_home_assistant_name</string>
     <string name="key_setting_mqtt_tls_enabled">setting_mqtt_tls_enabled</string>
     <string name="default_setting_mqtt_enabled">false</string>
+    <string name="default_setting_mqtt_home_assistant_discovery">false</string>
+    <string name="default_setting_mqtt_home_assistant_name">My Wall Panel</string>
     <string name="default_setting_mqtt_tts_enabled">false</string>
     <string name="default_setting_mqtt_basetopic">wallpanel/mywallpanel/</string>
     <string name="key_setting_mqtt_clientid">setting_mqtt_clientid</string>

--- a/WallPanelApp/src/main/res/values/strings.xml
+++ b/WallPanelApp/src/main/res/values/strings.xml
@@ -70,7 +70,9 @@
     <string name="title_setting_mqtt_password">Password (Optional)</string>
     <string name="title_setting_mqtt_sensorfrequency">Publish Frequency (in seconds)</string>
     <string name="title_setting_mqtt_home_assistant_discovery">Enable Discovery in Home Assistant</string>
-    <string name="title_setting_mqtt_home_assistant_name">Device Name in Home Assistant</string>
+    <string name="title_setting_mqtt_home_assistant_topic">Discovery Base Topic</string>
+    <string name="title_setting_mqtt_home_assistant_name">Device Display Name</string>
+    <string name="default_setting_mqtt_home_assistant_name">My Wall Panel</string>
     <string name="title_setting_android_startonboot">Open On Device Boot</string>
     <string name="title_setting_android_browsertype">Specify Browser Engine</string>
     <string name="default_setting_android_browsertype">Auto</string>
@@ -237,6 +239,17 @@
 
     <string name="preference_summary_image_rotation">Time in minutes between image refresh. Currently %1$s.</string>
     <string name="preference_title_image_rotation">Image Rotation Interval</string>
+    <string name="mqtt_sensor_battery_level">Battery Level</string>
+    <string name="mqtt_sensor_usb_plugged">USB Plugged</string>
+    <string name="mqtt_sensor_ac_plugged">AC Plugged</string>
+    <string name="mqtt_sensor_charging">Charging</string>
+    <string name="mqtt_sensor_temperature">Temperature</string>
+    <string name="mqtt_sensor_light">Light</string>
+    <string name="mqtt_sensor_magnetic_field">Magnetic Field</string>
+    <string name="mqtt_sensor_pressure">Pressure</string>
+    <string name="mqtt_sensor_humidity">Humidity</string>
+    <string name="mqtt_sensor_face_detected">Face Detected</string>
+    <string name="mqtt_sensor_motion_detected">Motion Detected</string>
 
 
     <string-array name="flip_directions">

--- a/WallPanelApp/src/main/res/values/strings.xml
+++ b/WallPanelApp/src/main/res/values/strings.xml
@@ -69,6 +69,8 @@
     <string name="title_setting_mqtt_username">Username (Optional)</string>
     <string name="title_setting_mqtt_password">Password (Optional)</string>
     <string name="title_setting_mqtt_sensorfrequency">Publish Frequency (in seconds)</string>
+    <string name="title_setting_mqtt_home_assistant_discovery">Enable Discovery in Home Assistant</string>
+    <string name="title_setting_mqtt_home_assistant_name">Device Name in Home Assistant</string>
     <string name="title_setting_android_startonboot">Open On Device Boot</string>
     <string name="title_setting_android_browsertype">Specify Browser Engine</string>
     <string name="default_setting_android_browsertype">Auto</string>

--- a/WallPanelApp/src/main/res/xml/pref_mqtt.xml
+++ b/WallPanelApp/src/main/res/xml/pref_mqtt.xml
@@ -72,16 +72,27 @@
             android:selectAllOnFocus="true"
             android:singleLine="true"
             android:title="@string/title_setting_mqtt_password" />
+        <SwitchPreference
+            android:defaultValue="@string/default_setting_mqtt_home_assistant_discovery"
+            android:key="@string/key_setting_mqtt_home_assistant_discovery"
+            android:title="@string/title_setting_mqtt_home_assistant_discovery" />
+        <EditTextPreference
+            android:defaultValue="@string/default_setting_mqtt_home_assistant_name"
+            android:dependency="@string/key_setting_mqtt_home_assistant_discovery"
+            android:key="@string/key_setting_mqtt_home_assistant_name"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:title="@string/title_setting_mqtt_home_assistant_name" />
 
     </PreferenceCategory>
 
-  <!--  <PreferenceCategory android:title="@string/pref_mqtt_settings_category">
+    <!--  <PreferenceCategory android:title="@string/pref_mqtt_settings_category">
 
-        <SwitchPreference
-            android:key="@string/key_pref_module_tss"
-            android:summary="@string/preference_summary_tts"
-            android:title="@string/preference_tts"/>
+          <SwitchPreference
+              android:key="@string/key_pref_module_tss"
+              android:summary="@string/preference_summary_tts"
+              android:title="@string/preference_tts"/>
 
-    </PreferenceCategory>-->
+      </PreferenceCategory>-->
 
 </PreferenceScreen>

--- a/WallPanelApp/src/main/res/xml/pref_mqtt.xml
+++ b/WallPanelApp/src/main/res/xml/pref_mqtt.xml
@@ -77,6 +77,13 @@
             android:key="@string/key_setting_mqtt_home_assistant_discovery"
             android:title="@string/title_setting_mqtt_home_assistant_discovery" />
         <EditTextPreference
+            android:defaultValue="@string/default_setting_mqtt_home_assistant_topic"
+            android:dependency="@string/key_setting_mqtt_home_assistant_discovery"
+            android:key="@string/key_setting_mqtt_home_assistant_topic"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:title="@string/title_setting_mqtt_home_assistant_topic" />
+        <EditTextPreference
             android:defaultValue="@string/default_setting_mqtt_home_assistant_name"
             android:dependency="@string/key_setting_mqtt_home_assistant_discovery"
             android:key="@string/key_setting_mqtt_home_assistant_name"


### PR DESCRIPTION
This adds [MQTT Discovery](https://www.home-assistant.io/docs/mqtt/discovery/)to the MQTT channel for the sensors on the wall panel. So you don't have to do anything in HA config for the wall panel devices to appear.
![image](https://user-images.githubusercontent.com/10632972/104111014-6d49d900-52d5-11eb-8116-28c9414eaa02.png)

Sorry, I don't know Kotlin or Android development, so there would probably be some cleaner ways to implement this. I also had to create a new version of publish, which didn't fill me with joy.

I had to re-order the calls to `listener?.handleMqttConnected()` because the attempts to publish to MQTT in the handler were being blocked.

I added a couple of settings to control the HA MQTT Discovery settings. They will be disabled by default.