### PR TITLE
Allow screen sleep while screensaver is active

### DIFF
--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/activities/BrowserActivity.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/activities/BrowserActivity.kt
@@ -143,6 +143,8 @@ abstract class BrowserActivity : DaggerAppCompatActivity() {
         filter.addAction(BROADCAST_SCREEN_WAKE)
         val bm = LocalBroadcastManager.getInstance(this)
         bm.registerReceiver(mBroadcastReceiver, filter)
+
+        resetInactivityTimer()
     }
 
     override fun onPause() {
@@ -278,7 +280,7 @@ abstract class BrowserActivity : DaggerAppCompatActivity() {
                             resetScreenBrightness(false)
                             resetInactivityTimer()
                         },
-                        configuration.hasScreenSaverWallpaper, configuration.hasClockScreenSaver, configuration.imageRotation.toLong())
+                        configuration.hasScreenSaverWallpaper, configuration.hasClockScreenSaver, configuration.imageRotation.toLong(), configuration.appPreventSleep)
             } catch (e: Exception) {
                 Timber.e(e.message)
             }

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/utils/DialogUtils.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/utils/DialogUtils.kt
@@ -132,7 +132,8 @@ class DialogUtils(base: Context?) : ContextWrapper(base), LifecycleObserver {
     fun showScreenSaver(activity: AppCompatActivity, onClickListener: View.OnClickListener,
                         hasWallpaper: Boolean,
                         hasClock: Boolean,
-                        rotationInterval: Long) {
+                        rotationInterval: Long,
+                        preventSleep: Boolean) {
         if (screenSaverDialog != null && screenSaverDialog!!.isShowing) {
             return
         }
@@ -143,7 +144,7 @@ class DialogUtils(base: Context?) : ContextWrapper(base), LifecycleObserver {
         screenSaverView.setOnClickListener(onClickListener)
         screenSaverView.init(hasWallpaper, hasClock, rotationInterval)
         screenSaverDialog = buildImmersiveDialog(activity, true, screenSaverView, true)
-        if (screenSaverDialog != null){
+        if (screenSaverDialog != null && preventSleep){
             screenSaverDialog?.window?.addFlags( WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON )
         }
     }


### PR DESCRIPTION
If the screen saver is enabled, respect the "Prevent Screen Sleep" option, instead of preventing sleep regardless.
Explicitly close the screensaver once the device is woken up - so that a double-tap or lock-button press is enough to wake the wall panel fully.

