### PR TITLE
Add face detection options

### DIFF
--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/CameraReader.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/modules/CameraReader.kt
@@ -341,13 +341,17 @@ constructor(private val context: Context) {
                         .setTrackingEnabled(false)
                         .setMode(FaceDetector.FAST_MODE)
                         .setClassificationType(FaceDetector.NO_CLASSIFICATIONS)
-                        .setLandmarkType(FaceDetector.NO_LANDMARKS)
+                        .setLandmarkType(FaceDetector.ALL_LANDMARKS)
                         .build()
 
                 faceDetectorProcessor = LargestFaceFocusingProcessor(faceDetector, object : Tracker<Face>() {
                     override fun onUpdate(detections: Detector.Detections<Face>, face: Face) {
                         super.onUpdate(detections, face)
-                        if (detections.detectedItems.size() > 0) {
+
+                        var faceSize = face.width / detections.frameMetadata.width * 100 > configuration.cameraFaceSize;
+                        var faceRotation = if (configuration.cameraFaceRotation) face.eulerY > -12 && face.eulerY < 12 else true;
+
+                        if (detections.detectedItems.size() > 0 && faceSize && faceRotation) {
                             if (cameraCallback != null && configuration.cameraFaceEnabled) {
                                 Timber.d("faceDetected")
                                 cameraCallback!!.onFaceDetected()

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/persistence/Configuration.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/persistence/Configuration.kt
@@ -114,6 +114,14 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
         get() = getBoolPref(R.string.key_setting_camera_facewake,
                 R.string.default_setting_camera_facewake)
 
+    val cameraFaceSize: Int
+        get() = getStringPref(R.string.key_setting_camera_facesize,
+                R.string.default_setting_camera_facesize).trim().toInt()
+
+    val cameraFaceRotation: Boolean
+        get() = getBoolPref(R.string.key_setting_camera_facerotation,
+                R.string.default_setting_camera_facerotation)
+
     var cameraQRCodeEnabled: Boolean
         get() = getBoolPref(R.string.key_setting_camera_qrcodeenabled,
                 R.string.default_setting_camera_qrcodeenabled)

--- a/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/FaceSettingsFragment.kt
+++ b/WallPanelApp/src/main/java/com/thanksmister/iot/wallpanel/ui/fragments/FaceSettingsFragment.kt
@@ -20,10 +20,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.preference.SwitchPreference
-import androidx.preference.CheckBoxPreference
 import androidx.preference.EditTextPreference
-import androidx.preference.ListPreference
-import androidx.preference.Preference
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -35,8 +32,10 @@ import dagger.android.support.AndroidSupportInjection
 
 class FaceSettingsFragment : BaseSettingsFragment() {
 
-    private var motionDetectionPreference: SwitchPreference? = null
-    private var motionDetectionPreference2: SwitchPreference? = null
+    private var faceDetectionPreference: SwitchPreference? = null
+    private var faceWakePreference: SwitchPreference? = null
+    private var faceSizePreference: EditTextPreference? = null
+    private var faceRotationPreference: SwitchPreference? = null
 
     override fun onAttach(context: Context) {
         AndroidSupportInjection.inject(this)
@@ -78,10 +77,25 @@ class FaceSettingsFragment : BaseSettingsFragment() {
 
         super.onViewCreated(view, savedInstanceState)
 
-        motionDetectionPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_camera_faceenabled)) as SwitchPreference
-        motionDetectionPreference2 = findPreference<SwitchPreference>(getString(R.string.key_setting_camera_facewake)) as SwitchPreference
+        faceDetectionPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_camera_faceenabled)) as SwitchPreference
+        faceWakePreference = findPreference<SwitchPreference>(getString(R.string.key_setting_camera_facewake)) as SwitchPreference
+        faceSizePreference = findPreference<EditTextPreference>(getString(R.string.key_setting_camera_facesize)) as EditTextPreference
+        faceRotationPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_camera_facerotation)) as SwitchPreference
 
-        bindPreferenceSummaryToValue(motionDetectionPreference!!)
-        bindPreferenceSummaryToValue(motionDetectionPreference2!!)
+        bindPreferenceSummaryToValue(faceDetectionPreference!!)
+        bindPreferenceSummaryToValue(faceWakePreference!!)
+        bindPreferenceSummaryToValue(faceRotationPreference!!)
+
+        faceSizePreference?.summary = getString(R.string.preference_summary_camera_facesize, configuration.cameraFaceSize.toString())
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+        when (key) {
+            getString(R.string.key_setting_camera_facesize)-> {
+                faceSizePreference?.text?.let {
+                    faceSizePreference?.summary = getString(R.string.preference_summary_camera_facesize, it)
+                }
+            }
+        }
     }
 }

--- a/WallPanelApp/src/main/res/values/donottranslate.xml
+++ b/WallPanelApp/src/main/res/values/donottranslate.xml
@@ -142,6 +142,12 @@
     <string name="key_setting_screensaver_brightness">setting_screensaver_brightness</string>
     <string name="default_setting_screensaver_brightness">15</string>
 
+    <string name="key_setting_camera_facesize">setting_camera_facesize</string>
+    <string name="default_setting_camera_facesize">0</string>
+
+    <string name="key_setting_camera_facerotation">setting_camera_facerotation</string>
+    <string name="default_setting_camera_facerotation">false</string>
+
     <string-array name="settings_titles">
         <item>@string/title_settings</item>
         <item>@string/title_camera_settings</item>

--- a/WallPanelApp/src/main/res/values/strings.xml
+++ b/WallPanelApp/src/main/res/values/strings.xml
@@ -238,6 +238,11 @@
     <string name="preference_summary_image_rotation">Time in minutes between image refresh. Currently %1$s.</string>
     <string name="preference_title_image_rotation">Image Rotation Interval</string>
 
+    <string name="preference_title_camera_facesize">Minimum Face Size</string>
+    <string name="preference_summary_camera_facesize">A face will be detected only if it takes more than %1$s\%% of the image.</string>
+
+    <string name="preference_title_camera_facerotation">Check Face Rotation</string>
+    <string name="preference_summary_camera_facerotation">A face will be detected only if it looks straight to the camera.</string>
 
     <string-array name="flip_directions">
         <item>None</item>

--- a/WallPanelApp/src/main/res/xml/pref_face.xml
+++ b/WallPanelApp/src/main/res/xml/pref_face.xml
@@ -31,6 +31,19 @@
             android:summary="@string/pref_face_wake_summary"
             android:dependency="@string/key_setting_camera_faceenabled"/>
 
+        <EditTextPreference
+            android:inputType="number"
+            android:key="@string/key_setting_camera_facesize"
+            android:selectAllOnFocus="true"
+            android:singleLine="true"
+            android:title="@string/preference_title_camera_facesize"/>
+
+        <SwitchPreference
+            android:defaultValue="@string/default_setting_camera_facerotation"
+            android:key="@string/key_setting_camera_facerotation"
+            android:title="@string/preference_title_camera_facerotation"
+            android:summary="@string/preference_summary_camera_facerotation"
+            android:dependency="@string/key_setting_camera_faceenabled"/>
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
I added two settings regarding face detection:

1. Face Size
As already mentioned in #149 #205, a face is detected even if it is far away from the camera. The library used has [getWidth](https://developers.google.com/android/reference/com/google/android/gms/vision/face/Face#getWidth()), which returns the width of the face. Setting this option to 50% will detect a face only if the face width is larger than 50% of the image width.

2. Face Rotation
By default a face is detected even with just the side-view of a person. The library used has [getEulerY](https://developers.google.com/android/reference/com/google/android/gms/vision/face/Face#getEulerY()), which returns the rotation of the face. Checking this option detects a face only if the rotation is between -12 and 12 degrees.